### PR TITLE
Merge sig-virtualization to sig-cluster-management

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - sig-virtualization
+  - sig-cluster-management
 
 reviewers:
-  - sig-virtualization
+  - sig-cluster-management
 
 labels:
-  - sig/virtualization
+  - sig/cluster-management

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,6 +2,12 @@
 # To change team associations, update the GitHub teams via https://github.com/kubermatic/access.
 
 aliases:
-  sig-virtualization:
-    - hdurand0710
-    - mfranczy
+  sig-cluster-management:
+    - ahmedwaleedmalik
+    - cnvergence
+    - embik
+    - kron4eg
+    - moadqassem
+    - moelsayed
+    - xmudrii
+    - xrstf


### PR DESCRIPTION
As discussed in the sig meetings, sig-virtualization will merge under the sig-cluster-management