### PR TITLE
Add Persistent Volume Claim Reconciler

### DIFF
--- a/controllers/persistentvolumeclaims/controller.go
+++ b/controllers/persistentvolumeclaims/controller.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2025 The KubeVirt CSI driver Operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaims
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const ControllerName = "persistent-volume-claims-controller"
+
+type Reconciler struct {
+	client.Client
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	l := log.FromContext(ctx)
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := r.Client.Get(ctx, req.NamespacedName, pvc); err != nil {
+		l.Error(err, "unable to get PVC", "pvc-name", req.NamespacedName)
+		return reconcile.Result{}, err
+	}
+
+	if err := r.reconcilePVCs(ctx, pvc); err != nil {
+		l.Error(err, "failed to reconcile PVC", "pvc-name", req.NamespacedName)
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.PersistentVolumeClaim{}).
+		Complete(r)
+}

--- a/controllers/persistentvolumeclaims/reconcile.go
+++ b/controllers/persistentvolumeclaims/reconcile.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The KubeVirt CSI driver Operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaims
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (r *Reconciler) reconcilePVCs(ctx context.Context, pvc *corev1.PersistentVolumeClaim) error {
+	if pvc.Status.Phase == corev1.ClaimBound {
+		assignedNodeName := pvc.Annotations["volume.kubernetes.io/selected-node"]
+		assignedNode := &corev1.Node{}
+		if err := r.Client.Get(ctx, client.ObjectKey{Name: assignedNodeName}, assignedNode); err != nil {
+			return err
+		}
+
+		zone := assignedNode.Labels["topology.kubernetes.io/zone"]
+		region := assignedNode.Labels["topology.kubernetes.io/region"]
+
+		pv := &corev1.PersistentVolume{}
+		if err := r.Client.Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, pv); err != nil {
+			return err
+		}
+
+		var nodeSelectorTerms []corev1.NodeSelectorTerm
+		if zone != "" {
+			nodeSelectorTerms = append(nodeSelectorTerms, corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "topology.kubernetes.io/zone",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{zone},
+					},
+				},
+			})
+		}
+
+		if region != "" {
+			nodeSelectorTerms = append(nodeSelectorTerms, corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "topology.kubernetes.io/region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{region},
+					},
+				},
+			})
+		}
+
+		if len(nodeSelectorTerms) > 0 {
+			pv.Spec.NodeAffinity = &corev1.VolumeNodeAffinity{
+				Required: &corev1.NodeSelector{
+					NodeSelectorTerms: nodeSelectorTerms,
+				},
+			}
+		}
+
+		pv = pv.DeepCopy()
+		if err := r.Client.Update(ctx, pv); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"flag"
 	"os"
 
+	"github.com/kubermatic/kubevirt-csi-driver-operator/controllers/persistentvolumeclaims"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -85,6 +87,14 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Tenant")
 		os.Exit(1)
 	}
+
+	if err = (&persistentvolumeclaims.Reconciler{
+		Client: mgr.GetClient(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", persistentvolumeclaims.ControllerName)
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
This PR adds support to update PVs to have the right node affinities to match the zones and regions where volumes exist. 

```release-note
Support KubeVirt PersistentVolumes Zone/Region Affinities 
```