### PR TITLE
Bump Go version in the Dockerfile and Upgrade Image Tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM golang:1.22.5 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/kubermatic/kubevirt-csi-driver-operator:v0.3.0
+IMG ?= quay.io/kubermatic/kubevirt-csi-driver-operator:v0.4.0
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 


### PR DESCRIPTION
We need to tag a new release fir the KubeVirt CSI Driver Operator, in addition to bumping the go version in the Dockerfile. 

```release-note
Bump Go version and upgrade image tag
``` 