### PR TITLE
Support overwrite image registry

### DIFF
--- a/controllers/tenant/controller.go
+++ b/controllers/tenant/controller.go
@@ -46,6 +46,8 @@ const (
 type TenantReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	OverwriteRegistry string
 }
 
 //+kubebuilder:rbac:groups=csiprovisioner.kubevirt.io,resources=tenants,verbs=get;list;watch

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kubermatic/kubevirt-csi-driver-operator
 go 1.22.4
 
 require (
+	github.com/distribution/reference v0.6.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.23.0
 	k8s.io/api v0.25.3
@@ -51,6 +52,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/emicklei/go-restful/v3 v3.8.0 h1:eCZ8ulSerjdAiaNpF7GxXIE7ZCMo1moN1qX+S609eVw=
 github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
@@ -292,6 +294,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.23.0 h1:/oxKu9c2HVap+F3PfKort2Hw5DEU+HGlW8n+tguWsys=
 github.com/onsi/gomega v1.23.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/main.go
+++ b/main.go
@@ -51,11 +51,16 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
-	var probeAddr string
+	var (
+		metricsAddr          string
+		enableLeaderElection bool
+		probeAddr            string
+		overwriteRegistry    string
+	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&overwriteRegistry, "overwrite-registry", "", "registry to use for all images")
+
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -81,8 +86,9 @@ func main() {
 	}
 
 	if err = (&tenant.TenantReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		OverwriteRegistry: overwriteRegistry,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Tenant")
 		os.Exit(1)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025 The KubeVirt CSI driver Operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package registry groups all container registry related types and helpers in one place.
+package registry
+
+import (
+	"fmt"
+
+	"github.com/distribution/reference"
+)
+
+const (
+	// RegistryDocker defines the default docker.io registry.
+	RegistryDocker = "docker.io"
+	// RegistryQuay defines the image registry from coreos/redhat - quay.
+	RegistryQuay = "quay.io"
+)
+
+func Must(s string, err error) string {
+	if err != nil {
+		panic(err)
+	}
+
+	return s
+}
+
+// WithOverwriteFunc is a function that takes a string and either returns that string or a defined override value.
+type WithOverwriteFunc func(string) string
+
+// ImageRewriter is a function that takes a Docker image reference
+// (for example "docker.io/repo/image:tag@sha256:abc123") and
+// potentially changes the registry to point to a local registry.
+// It's a distinct type from WithOverwriteFunc as it does not just
+// work on a registry, but a full image reference.
+type ImageRewriter func(string) (string, error)
+
+// GetImageRewriterFunc returns a ImageRewriter that will apply the given
+// overwriteRegistry to a given docker image reference.
+func GetImageRewriterFunc(overwriteRegistry string) ImageRewriter {
+	return func(image string) (string, error) {
+		return RewriteImage(image, overwriteRegistry)
+	}
+}
+
+// RewriteImage will apply the given overwriteRegistry to a given docker
+// image reference.
+func RewriteImage(image, overwriteRegistry string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return "", fmt.Errorf("invalid reference %q: %w", image, err)
+	}
+
+	domain := reference.Domain(named)
+	origDomain := domain
+	if origDomain == "" {
+		origDomain = RegistryDocker
+	}
+
+	if overwriteRegistry != "" {
+		domain = overwriteRegistry
+	}
+	if domain == "" {
+		domain = RegistryDocker
+	}
+
+	// construct name image name
+	image = domain + "/" + reference.Path(named)
+
+	if tagged, ok := named.(reference.Tagged); ok {
+		image += ":" + tagged.Tag()
+	}
+
+	// If the registry (domain) has been changed, remove the
+	// digest as it's unlikely that a) the repo digest has
+	// been kept when mirroring the image and b) the chance
+	// of a local registry being poisoned with bad images is
+	// much lower anyhow.
+	if origDomain == domain {
+		if digested, ok := named.(reference.Digested); ok {
+			image += "@" + string(digested.Digest())
+		}
+	}
+
+	return image, nil
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The KubeVirt CSI driver Operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"testing"
+)
+
+func TestImageRewriter(t *testing.T) {
+	addDigest := func(s string) string {
+		return s + "@sha256:0b2f19895de281e4a416700b17a4dc9b8d3b80eb7b5b65dac173880f5113084e"
+	}
+
+	testcases := []struct {
+		name      string
+		overwrite string
+		input     string
+		expected  string
+	}{
+		{
+			name:      "default registry is applied",
+			overwrite: "",
+			input:     "foo/bar",
+			expected:  "docker.io/foo/bar",
+		},
+		{
+			name:      "tags are kept",
+			overwrite: "",
+			input:     "foo/bar:v1.2.3",
+			expected:  "docker.io/foo/bar:v1.2.3",
+		},
+		{
+			name:      "digests are kept if the registry is unchanged (with default registry)",
+			overwrite: "",
+			input:     addDigest("foo/bar:v1.2.3"),
+			expected:  addDigest("docker.io/foo/bar:v1.2.3"),
+		},
+		{
+			name:      "digests are kept if the registry is unchanged",
+			overwrite: "",
+			input:     addDigest("docker.io/foo/bar:v1.2.3"),
+			expected:  addDigest("docker.io/foo/bar:v1.2.3"),
+		},
+		{
+			name:      "untagged digests are kept if the registry is unchanged (with default registry)",
+			overwrite: "",
+			input:     addDigest("foo/bar"),
+			expected:  addDigest("docker.io/foo/bar"),
+		},
+		{
+			name:      "untagged digests are kept if the registry is unchanged",
+			overwrite: "",
+			input:     addDigest("docker.io/foo/bar"),
+			expected:  addDigest("docker.io/foo/bar"),
+		},
+		{
+			name:      "images can survive unchanged",
+			overwrite: "",
+			input:     "docker.io/foo/bar",
+			expected:  "docker.io/foo/bar",
+		},
+		{
+			name:      "a registry overwrite is applied",
+			overwrite: "registry.local",
+			input:     "docker.io/foo/bar",
+			expected:  "registry.local/foo/bar",
+		},
+		{
+			name:      "a registry overwrite will remove the digest",
+			overwrite: "registry.local",
+			input:     addDigest("docker.io/foo/bar:v1.2.3"),
+			expected:  "registry.local/foo/bar:v1.2.3",
+		},
+		{
+			name:      "a NOP rewrite should keep the digest",
+			overwrite: "registry.local",
+			input:     addDigest("registry.local/foo/bar:v1.2.3"),
+			expected:  addDigest("registry.local/foo/bar:v1.2.3"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			rewriter := GetImageRewriterFunc(testcase.overwrite)
+
+			output, err := rewriter(testcase.input)
+			if err != nil {
+				t.Fatalf("Expected no error, but got: %v", err)
+			}
+
+			if output != testcase.expected {
+				t.Fatalf("Expected %q to write to %q (with overwrite %q), but got %q.", testcase.input, testcase.expected, testcase.overwrite, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support to overwrite the image registry for the daemonset of the csi driver to support custom image registries especially in air-gabbed setup. 

```release-note
Support overwrite kubevirt csi driver operator registry 
```