### PR TITLE
Update csi driver images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.22.5 as builder
+FROM golang:1.23.2 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -27,6 +27,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY registry/ registry/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/controllers/tenant/daemonset.go
+++ b/controllers/tenant/daemonset.go
@@ -87,7 +87,7 @@ func getDesiredDaemonSet(obj metav1.Object, imageRegistry, imageRepository, imag
 								AllowPrivilegeEscalation: pointer.Bool(true),
 							},
 							ImagePullPolicy: corev1.PullAlways,
-							Image:           registry.Must(registry.RewriteImage("kubermatic/kubevirt-csi-driver:35836e0c8b68d9916d29a838ea60cdd3fc6199cf", imageRegistry)),
+							Image:           registry.Must(registry.RewriteImage("kubermatic/kubevirt-csi-driver:9ad38f9e49c296acfe7b9d3301ebff8a1056fa68", imageRegistry)),
 							Args: []string{
 								"--endpoint=unix:/csi/csi.sock",
 								"--node-name=$(KUBE_NODE_NAME)",
@@ -155,7 +155,7 @@ func getDesiredDaemonSet(obj metav1.Object, imageRegistry, imageRepository, imag
 								Privileged: pointer.BoolPtr(true),
 							},
 							ImagePullPolicy: corev1.PullAlways,
-							Image:           registry.Must(registry.RewriteImage("openshift/origin-csi-node-driver-registrar:4.13.0", imageRegistry)),
+							Image:           registry.Must(registry.RewriteImage("openshift/origin-csi-node-driver-registrar:4.20.0", imageRegistry)),
 							Args: []string{
 								"--csi-address=$(ADDRESS)",
 								"--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)",
@@ -200,7 +200,7 @@ func getDesiredDaemonSet(obj metav1.Object, imageRegistry, imageRepository, imag
 						{
 							Name:            "csi-liveness-probe",
 							ImagePullPolicy: corev1.PullAlways,
-							Image:           registry.Must(registry.RewriteImage("openshift/origin-csi-livenessprobe:4.13.0", imageRegistry)),
+							Image:           registry.Must(registry.RewriteImage("openshift/origin-csi-livenessprobe:4.20.0", imageRegistry)),
 							Args: []string{
 								"--csi-address=/csi/csi.sock",
 								"--probe-timeout=3s",


### PR DESCRIPTION
This PR bumps the kubevirt csi driver images o the latest upstream images to fix couple of issues related to the VM volumes attachment and cleanups. https://github.com/kubevirt/csi-driver/pull/130 

```release-note
Bump KubeVirt CSI Driver to commit `9ad38f9e49c296acfe7b9d3301ebff8a1056fa68`
```