### PR TITLE
Bump kubevirt csi driver verion to v0.4.5

### DIFF
--- a/controllers/tenant/daemonset.go
+++ b/controllers/tenant/daemonset.go
@@ -87,7 +87,7 @@ func getDesiredDaemonSet(obj metav1.Object, imageRegistry, imageRepository, imag
 								AllowPrivilegeEscalation: pointer.Bool(true),
 							},
 							ImagePullPolicy: corev1.PullAlways,
-							Image:           registry.Must(registry.RewriteImage("kubermatic/kubevirt-csi-driver:9ad38f9e49c296acfe7b9d3301ebff8a1056fa68", imageRegistry)),
+							Image:           registry.Must(registry.RewriteImage("kubermatic/kubevirt-csi-driver:v0.4.5", imageRegistry)),
 							Args: []string{
 								"--endpoint=unix:/csi/csi.sock",
 								"--node-name=$(KUBE_NODE_NAME)",


### PR DESCRIPTION
The KubeVirt CSI Driver v0.4.5 is equivalent to `a8d6605bc9997bcfda3fb9f1f82ba6445b4984cc`   

```release-note
Bump KubeVirt CSI driver to a8d6605bc9997bcfda3fb9f1f82ba6445b4984cc commit
```