### PR TITLE
Reduce errors if the selected-node annotations is stale

### DIFF
--- a/controllers/persistentvolumeclaims/reconcile.go
+++ b/controllers/persistentvolumeclaims/reconcile.go
@@ -41,18 +41,27 @@ func (r *Reconciler) reconcilePVCs(ctx context.Context, pvc *corev1.PersistentVo
 	assignedNodeName := pvc.Annotations["volume.kubernetes.io/selected-node"]
 
 	if pvc.Status.Phase == corev1.ClaimBound && sc.Provisioner == provisioner && assignedNodeName != "" {
-		assignedNode := &corev1.Node{}
-		if err := r.Client.Get(ctx, client.ObjectKey{Name: assignedNodeName}, assignedNode); err != nil {
-			return err
-		}
-
-		zone := assignedNode.Labels["topology.kubernetes.io/zone"]
-		region := assignedNode.Labels["topology.kubernetes.io/region"]
 
 		pv := &corev1.PersistentVolume{}
 		if err := r.Client.Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, pv); err != nil {
 			return err
 		}
+
+		assignedNode := &corev1.Node{}
+		if err := r.Client.Get(ctx, client.ObjectKey{Name: assignedNodeName}, assignedNode); err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				// If the assigned node is not found, it might have been deleted. If the NodeAffinity is already set, we can ignore this error, otherwise we should return it to trigger a retry.
+				if pv.Spec.NodeAffinity != nil {
+					return nil
+				}
+				return fmt.Errorf("assigned node %s not found for pvc %s and NodeAffinity is not set", assignedNodeName, pvc.Name)
+			}
+
+			return err
+		}
+
+		zone := assignedNode.Labels["topology.kubernetes.io/zone"]
+		region := assignedNode.Labels["topology.kubernetes.io/region"]
 
 		var matchExpressions []corev1.NodeSelectorRequirement
 


### PR DESCRIPTION
If a PVC has the `volume.kubernetes.io/selected-node` annotation set, but the referenced node no longer exists, the operator logs a ton of error messages. 

These can be a red herring when debugging issues with PVC provisioning.

This PR handles the Node not found error more gracefully, by adding a check if the NodeAffinity is already present on the PV, and if so supressing the error.

The ideal solution would be for the csi provisioner to manage this annotation, but it is quite common that this doesn't happend and has caused issues in other projects as well (for example: https://github.com/kubernetes/kubernetes/issues/89953 https://github.com/vmware-tanzu/velero/issues/8878 )

**What type of PR is this?**
/kind cleanup

```release-note
Do not log Node not found errors if NodeAffinity is already set
```
